### PR TITLE
Adding buffer support

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -38,7 +38,8 @@ describe("Test for PositionFile", () => {
 
     expect(writeFileSync).toHaveBeenCalledWith(
       resolve("./my-file.txt"),
-      "content of my file"
+      "content of my file",
+      undefined
     );
   });
 
@@ -64,7 +65,8 @@ describe("Test for PositionFile", () => {
 
       expect(writeFileSync).toHaveBeenCalledWith(
         resolve(`./my-file (${expectedNumber}).txt`),
-        "content of my file"
+        "content of my file",
+        undefined
       );
     }
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const positionFile = (
   let filepath = path;
   if (fileExists) {
     filepath = getFilename(filepath);
-    positionFile(path, data, options);
+    positionFile(filepath, data, options);
   } else {
     writeFileSync(filepath, data, options);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,21 @@
-import { writeFileSync, existsSync } from "fs";
+import { writeFileSync, existsSync, WriteFileOptions } from "fs";
+
 import getFilename from "./get-filename";
 
-const positionFile = (path: string, content: string) => {
+const positionFile = (
+  path: string,
+  // eslint-disable-next-line no-undef
+  data: string | NodeJS.ArrayBufferView,
+  options?: WriteFileOptions | undefined
+) => {
   const fileExists = existsSync(path);
 
   let filepath = path;
   if (fileExists) {
     filepath = getFilename(filepath);
-    positionFile(filepath, content);
+    positionFile(path, data, options);
   } else {
-    writeFileSync(filepath, content);
+    writeFileSync(filepath, data, options);
   }
 };
 


### PR DESCRIPTION
This PR adds buffer support and other options for file positioning based on `fs.writeFile`. Previously it only supported string based content for a file